### PR TITLE
Fixed path to Vysor.exe

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,7 @@ class VysorBinary {
 async function findVysorBinary(): Promise<VysorBinary> {
     let vb: string|undefined;
     if (process.platform === 'win32') {
-        vb = path.join(getUserHome(), 'Local/Vysor/Vysor.exe');
+        vb = path.join(getUserHome(), 'AppData/Local/Vysor/Vysor.exe');
     }
     else if (process.platform === 'darwin') {
         vb = '/Applications/Vysor.app/Contents/MacOS/Vysor';


### PR DESCRIPTION
The path to Vysor.exe is incorrect, this is the fix. Right now it goes to `C:\Users\User\Local\Vysor\Vysor.exe` but this fix corrects the path to `C:\Users\User\AppData\Local\Vysor\Vysor.exe`.